### PR TITLE
fix: Enterprise-grade CGO_ENABLED=1 error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - v0.5.0: Builder pattern API, variadic functions
 - v1.0.0: LTS release with API stability guarantee
 
+## [0.3.8] - 2026-01-24
+
+### Fixed
+- **CGO_ENABLED=1 build error handling** ([gogpu/wgpu#43](https://github.com/gogpu/wgpu/issues/43))
+  - Users on Linux/macOS with gcc/clang installed got confusing linker errors
+  - Root cause: Assembly files compiled under CGO=1 but referenced undefined symbols
+  - Solution: Enterprise-grade error handling with compile-time + runtime guards
+
+### Added
+- **Compile-time CGO detection** with descriptive error identifier
+  - `undefined: GOFFI_REQUIRES_CGO_ENABLED_0` - immediately clear what's wrong
+  - Godoc comment in `cgo_unsupported.go` with full instructions
+  - Runtime panic fallback with detailed fix instructions
+
+- **Requirements section in README.md**
+  - Clear documentation that `CGO_ENABLED=0` is required
+  - Three options for setting CGO_ENABLED
+  - Explanation of why this is needed (cgo_import_dynamic mechanism)
+
+### Changed
+- `internal/dl/dl_stubs_unix.s` - Added `!cgo` build constraint
+- `internal/dl/dl_wrappers_unix.s` - Added `!cgo` build constraint
+- `internal/dl/dl_stubs_arm64.s` - Added `!cgo` build constraint
+- `internal/dl/dl_wrappers_arm64.s` - Added `!cgo` build constraint
+- `ffi/dl_unix.go` - Added `!cgo` build constraint
+- `ffi/dl_darwin.go` - Added `!cgo` build constraint
+
+### Technical Details
+- goffi uses `cgo_import_dynamic` for dynamic library loading without CGO
+- This mechanism only works when `CGO_ENABLED=0`
+- On Linux/macOS with C compiler installed, Go defaults to `CGO_ENABLED=1`
+- New error handling provides clear guidance instead of cryptic linker errors
+
 ## [0.3.7] - 2026-01-03
 
 ### Added
@@ -630,7 +663,11 @@ See [API_TODO.md](docs/dev/API_TODO.md) for detailed roadmap to v1.0.
 
 ---
 
-[Unreleased]: https://github.com/go-webgpu/goffi/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/go-webgpu/goffi/compare/v0.3.8...HEAD
+[0.3.8]: https://github.com/go-webgpu/goffi/compare/v0.3.7...v0.3.8
+[0.3.7]: https://github.com/go-webgpu/goffi/compare/v0.3.6...v0.3.7
+[0.3.6]: https://github.com/go-webgpu/goffi/compare/v0.3.5...v0.3.6
+[0.3.5]: https://github.com/go-webgpu/goffi/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/go-webgpu/goffi/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/go-webgpu/goffi/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/go-webgpu/goffi/compare/v0.3.1...v0.3.2

--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ ffi.CallFunction(&cif, wgpuCreateInstance, &result, args)
 go get github.com/go-webgpu/goffi
 ```
 
+### Requirements
+
+goffi requires `CGO_ENABLED=0` to build. This is automatic when:
+- No C compiler is installed, or
+- Cross-compiling to a different OS/architecture
+
+If you have gcc/clang installed and get build errors, use:
+
+```bash
+CGO_ENABLED=0 go build ./...
+```
+
+Or set it permanently:
+
+```bash
+go env -w CGO_ENABLED=0
+```
+
+> **Why?** goffi uses Go's `cgo_import_dynamic` mechanism for dynamic library loading,
+> which only works when CGO is disabled. This allows goffi to call C functions without
+> requiring a C compiler at build time.
+
 ### Basic Example
 
 ```go
@@ -348,4 +370,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 **Made with ❤️ for GPU computing in pure Go**
 
-*Last updated: 2026-01-03 | goffi v0.3.7*
+*Last updated: 2026-01-24 | goffi v0.3.8*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: Build production-ready Zero-CGO FFI with benchmarked performance
 > **Philosophy**: Performance first, usability second, platform coverage third
 
-**Last Updated**: 2025-11-28 | **Current Version**: v0.2.1 | **Strategy**: Benchmarks → Callbacks → ARM64 → API → v1.0 LTS | **Milestone**: v0.2.1 RELEASED! → v0.3.0 ARM64 (Q1 2025) → v1.0.0 LTS (Q1 2026)
+**Last Updated**: 2026-01-24 | **Current Version**: v0.3.8 | **Strategy**: Benchmarks → Callbacks → ARM64 → API → v1.0 LTS | **Milestone**: v0.3.8 RELEASED! → v0.5.0 Usability (Q2 2025) → v1.0.0 LTS (Q1 2026)
 
 ---
 
@@ -47,8 +47,10 @@ v0.1.1 (macOS SUPPORT) ✅ RELEASED 2025-11-18
 v0.2.0 (CALLBACKS) ✅ RELEASED 2025-11-27
          ↓ (1 day - Windows hotfix)
 v0.2.1 (WINDOWS HOTFIX) ✅ RELEASED 2025-11-27
-         ↓ (in progress - ARM64 implementation)
-v0.3.0 (ARM64 SUPPORT) → Q1 2025
+         ↓ (ARM64 implementation)
+v0.3.0-v0.3.7 (ARM64 SUPPORT) ✅ RELEASED 2025-12-29
+         ↓ (CGO error handling)
+v0.3.8 (CGO ERROR HANDLING) ✅ RELEASED 2026-01-24
          ↓ (2-3 months)
 v0.5.0 (USABILITY + VARIADIC) → Q2 2025
          ↓ (2-3 months)
@@ -83,11 +85,17 @@ v1.0.0 LTS → Long-term support release (Q1 2026)
 - SEH exception limitation documented
 - Platform-specific callback implementations
 
-**v0.3.0** = ARM64 support 🟡 IN DEVELOPMENT
+**v0.3.0-v0.3.7** = ARM64 support ✅ RELEASED (2025-12-29)
 - **ARM64 architecture support** (Linux + macOS AAPCS64 ABI)
-- Cross-compile verified, awaiting real hardware testing
-- Feature branch: `feature/arm64-support`
-- Requested by: go-webgpu project (Apple Silicon support)
+- Tested on Apple Silicon M3 Pro (64 ns/op)
+- HFA returns, nested structs, mixed int/float support
+- Contributed by: @ppoage (PR #9)
+
+**v0.3.8** = CGO error handling ✅ RELEASED (2026-01-24)
+- **Enterprise-grade CGO_ENABLED=1 error handling**
+- Compile-time assertion: `GOFFI_REQUIRES_CGO_ENABLED_0`
+- Clear documentation in README.md Requirements section
+- Fixes confusing linker errors on Linux/macOS with gcc/clang
 
 **v0.5.0** = Usability + Variadic (Q2 2025)
 - Builder pattern API
@@ -102,36 +110,40 @@ v1.0.0 LTS → Long-term support release (Q1 2026)
 
 ---
 
-## 📊 Current Status (v0.1.0)
+## 📊 Current Status (v0.3.8)
 
-**Phase**: ✅ Performance Validated + Production Ready
+**Phase**: ✅ ARM64 Complete + Production Ready
 
 **What Works**:
 - ✅ Dynamic library loading (`LoadLibrary`, `GetSymbol`, `FreeLibrary`)
 - ✅ Function call interface (`PrepareCallInterface`)
 - ✅ Function execution (`CallFunction`, `CallFunctionContext`)
-- ✅ **Benchmarks**: 88-114 ns/op FFI overhead ✨
+- ✅ **Benchmarks**: 64-114 ns/op FFI overhead ✨
 - ✅ **Typed errors**: 5 error types with `errors.As()` support
 - ✅ **Context support**: Timeouts and cancellation
-- ✅ **Cross-platform**: Linux + Windows AMD64
+- ✅ **Cross-platform**: Linux + Windows + macOS (AMD64 + ARM64)
 - ✅ **Type system**: Predefined descriptors for common types
-- ✅ **89.1% test coverage** (exceeded 80% target)
+- ✅ **Callbacks**: C-to-Go function calls (2000 entries)
+- ✅ **89.6% test coverage** (exceeded 80% target)
 
 **Performance**:
-- ✅ BenchmarkGoffiOverhead: **88.09 ns/op** (empty function)
-- ✅ BenchmarkGoffiIntArgs: **113.9 ns/op** (integer args)
-- ✅ BenchmarkGoffiStringOutput: **97.81 ns/op** (string processing)
-- ✅ BenchmarkDirectGo: **0.21 ns/op** (baseline)
+- ✅ AMD64: **88-114 ns/op** (Intel i7-1255U)
+- ✅ ARM64: **64 ns/op** (Apple M3 Pro)
 - ✅ **Verdict**: < 5% overhead for WebGPU operations (target achieved!)
 
 **Platform Support**:
 - ✅ Linux AMD64 (System V ABI)
 - ✅ Windows AMD64 (Win64 ABI)
-- ✅ macOS AMD64 (System V ABI) - v0.1.1
-- 🟡 ARM64 Linux/macOS (AAPCS64 ABI) - in development for v0.3.0
+- ✅ macOS AMD64 (System V ABI)
+- ✅ Linux ARM64 (AAPCS64 ABI)
+- ✅ macOS ARM64 (AAPCS64 ABI) - Apple Silicon M1/M2/M3/M4
+
+**Requirements**:
+- ✅ `CGO_ENABLED=0` required (clear error message if CGO_ENABLED=1)
+- ✅ Go 1.21+ recommended
 
 **Documentation**:
-- ✅ README.md with real benchmarks
+- ✅ README.md with benchmarks and requirements
 - ✅ docs/PERFORMANCE.md (comprehensive guide)
 - ✅ CHANGELOG.md with migration guide
 - ✅ CONTRIBUTING.md
@@ -141,35 +153,6 @@ v1.0.0 LTS → Long-term support release (Q1 2026)
 ---
 
 ## 📅 What's Next
-
-### **v0.3.0 - ARM64 Support** (Q1 2025) 🟡 IN DEVELOPMENT
-
-**Goal**: Full ARM64 platform support for Apple Silicon and Linux ARM64
-
-**Status**: Cross-compile verified, awaiting real hardware testing
-
-**Completed**:
-- ✅ `internal/arch/arm64/` - Implementation, classification, call_unix
-- ✅ `internal/syscall/arm64` - Call8Float wrapper and assembly
-- ✅ `internal/dl/arm64` - Dynamic loader stubs and wrappers
-- ✅ `ffi/callback_arm64` - 2000-entry trampoline table
-- ✅ Cross-compile: `GOOS=linux GOARCH=arm64` builds
-- ✅ Cross-compile: `GOOS=darwin GOARCH=arm64` builds (Apple Silicon)
-
-**Pending**:
-- [ ] Real ARM64 hardware testing (Linux ARM64 / macOS M1+)
-- [ ] CI/CD ARM64 runners (GitHub Actions `macos-latest`)
-- [ ] Performance benchmarks on ARM64
-- [ ] Documentation updates
-
-**ARM64 AAPCS64 ABI Implementation**:
-- X0-X7: 8 integer/pointer registers
-- D0-D7: 8 floating-point registers
-- X8: Indirect result location
-- Homogeneous Floating-point Aggregate (HFA) support
-- 2000 callback trampolines
-
----
 
 ### **v0.5.0 - Usability + Variadic** (Q2 2025)
 
@@ -306,11 +289,12 @@ v1.0.0 LTS → Long-term support release (Q1 2026)
 
 ## 📊 Quality Metrics
 
-**Current (v0.1.0)**:
-- ✅ Test coverage: 89.1% (target: 80%+)
+**Current (v0.3.8)**:
+- ✅ Test coverage: 89.6% (target: 80%+)
 - ✅ Linter issues: 0
-- ✅ Benchmarks: 88-114 ns/op
-- ✅ Platforms: 2 (Linux, Windows AMD64)
+- ✅ Benchmarks: 64-114 ns/op (AMD64 + ARM64)
+- ✅ Platforms: 5 (Linux, Windows, macOS × AMD64/ARM64)
+- ✅ CGO requirement: Clear error message
 
 **Target (v1.0.0)**:
 - 🎯 Test coverage: 90%+
@@ -361,5 +345,5 @@ v1.0.0 LTS → Long-term support release (Q1 2026)
 
 ---
 
-*Version 1.1 (Updated 2025-11-28)*
-*Current: v0.2.1 (Callbacks + Windows Hotfix) | Phase: ARM64 Development | Next: v0.3.0 (ARM64) | Target: v1.0.0 LTS (Q1 2026)*
+*Version 1.2 (Updated 2026-01-24)*
+*Current: v0.3.8 (ARM64 + CGO Error Handling) | Phase: Production Ready | Next: v0.5.0 (Usability) | Target: v1.0.0 LTS (Q1 2026)*

--- a/ffi/cgo_unsupported.go
+++ b/ffi/cgo_unsupported.go
@@ -1,0 +1,65 @@
+//go:build (linux || darwin) && cgo
+
+// Package ffi cannot be built with CGO_ENABLED=1.
+//
+// goffi is a pure Go FFI library that uses Go's cgo_import_dynamic mechanism
+// for dynamic library loading. This mechanism only works when CGO is disabled.
+//
+// To fix this error, build with CGO disabled:
+//
+//	CGO_ENABLED=0 go build ./...
+//
+// Or set permanently:
+//
+//	go env -w CGO_ENABLED=0
+//
+// For cross-compilation, CGO is automatically disabled:
+//
+//	GOOS=linux GOARCH=arm64 go build ./...
+//
+// For more information, see:
+//
+//	https://github.com/go-webgpu/goffi#requirements
+
+package ffi
+
+// Compile-time assertion: build fails immediately with descriptive error.
+// The identifier name explains the issue; see package documentation above for details.
+var _ = GOFFI_REQUIRES_CGO_ENABLED_0
+
+// Runtime fallback: provides detailed instructions if compile-time check is bypassed.
+// This should never execute under normal circumstances.
+func init() {
+	panic(`
+================================================================================
+goffi: CGO_ENABLED=1 is not supported
+================================================================================
+
+goffi is a pure Go FFI library that requires CGO_ENABLED=0 to build.
+
+This error occurs because:
+  - You have a C compiler (gcc/clang) installed
+  - Go automatically enables CGO when a C compiler is available
+  - goffi uses Go's cgo_import_dynamic mechanism which only works with CGO_ENABLED=0
+
+To fix this error, build with CGO disabled:
+
+  Option 1: Set for single build
+    CGO_ENABLED=0 go build ./...
+
+  Option 2: Set for current shell session
+    export CGO_ENABLED=0
+    go build ./...
+
+  Option 3: Set permanently via go env
+    go env -w CGO_ENABLED=0
+
+For cross-compilation, CGO is automatically disabled:
+    GOOS=linux GOARCH=arm64 go build ./...
+
+For more information:
+  https://github.com/go-webgpu/goffi#requirements
+
+================================================================================
+`)
+}

--- a/ffi/dl_darwin.go
+++ b/ffi/dl_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin && (amd64 || arm64)
+//go:build darwin && (amd64 || arm64) && !cgo
 
 // macOS library loading - OUR OWN implementation (NO dependencies!)
 //

--- a/ffi/dl_unix.go
+++ b/ffi/dl_unix.go
@@ -1,4 +1,4 @@
-//go:build linux && (amd64 || arm64)
+//go:build linux && (amd64 || arm64) && !cgo
 
 // Linux library loading - OUR OWN implementation (NO dependencies!)
 //

--- a/internal/dl/dl_stubs_arm64.s
+++ b/internal/dl/dl_stubs_arm64.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64
+//go:build (linux || darwin) && arm64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/dl/dl_stubs_unix.s
+++ b/internal/dl/dl_stubs_unix.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64
+//go:build (linux || darwin) && amd64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/dl/dl_wrappers_arm64.s
+++ b/internal/dl/dl_wrappers_arm64.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64
+//go:build (linux || darwin) && arm64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/dl/dl_wrappers_unix.s
+++ b/internal/dl/dl_wrappers_unix.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64
+//go:build (linux || darwin) && amd64 && !cgo
 
 #include "textflag.h"
 


### PR DESCRIPTION
## Summary

This PR implements enterprise-grade error handling for users who accidentally build with `CGO_ENABLED=1` on Linux/macOS.

### Problem
Users on Linux/macOS with gcc/clang installed get confusing linker errors when building goffi:
```
undefined: purego_dlopen
undefined: purego_dlsym
```

**Root cause**: Assembly files compiled under CGO=1 but referenced undefined symbols from files that only compile under CGO=0.

### Solution
Three-layer defense with clear error messaging:

1. **Compile-time assertion** - Build fails immediately with descriptive identifier:
   ```
   ffi/cgo_unsupported.go:28:9: undefined: GOFFI_REQUIRES_CGO_ENABLED_0
   ```

2. **Godoc documentation** - Opening the file shows full instructions in package comment

3. **Runtime fallback** - Detailed panic message with fix instructions (belt-and-suspenders)

### Changes

**Code changes:**
- `ffi/cgo_unsupported.go` - NEW: Enterprise-grade error stub
- `ffi/dl_unix.go` - Added `!cgo` build constraint
- `ffi/dl_darwin.go` - Added `!cgo` build constraint
- `internal/dl/*.s` (4 files) - Added `!cgo` build constraint

**Documentation:**
- `README.md` - Added Requirements section with clear instructions
- `CHANGELOG.md` - v0.3.8 release notes
- `ROADMAP.md` - Updated to reflect current status (v0.3.8)

## Test Plan

- [x] `CGO_ENABLED=0 go build ./...` passes on Windows
- [x] `CGO_ENABLED=0 go build ./...` passes on Linux (Gentoo WSL2)
- [x] `CGO_ENABLED=1 go build ./ffi` shows compile-time error on Linux
- [x] `CGO_ENABLED=0 go test ./ffi ./types` passes
- [x] `gofmt` - no formatting issues
- [x] `golangci-lint` - 0 issues

## Related Issues

Closes gogpu/wgpu#43