### PR TITLE
docs: update purego comparison with verified source claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,20 +216,22 @@ if err != nil {
 |---------|-----------|--------|-----|
 | C compiler required | No | No | Yes |
 | API style | libffi-like (prepare once, call many) | reflect-based (RegisterFunc) | Native |
-| Per-call allocations | Zero (CIF reusable) | sync.Pool per call | Zero |
-| Struct pass/return | Full (RAX+RDX, sret) | Full | Full |
-| Callback float returns | XMM0 in asm | panic | Full |
-| ARM64 HFA detection | Recursive (nested structs) | Top-level only | Full |
+| Per-call allocations | Zero (CIF reusable) | reflect + sync.Pool per call | Zero |
+| Struct pass/return | Full (RAX+RDX, sret) | Partial (no Windows structs) | Full |
+| Callback float returns | XMM0 in asm | Not supported (panic) | Full |
+| ARM64 HFA detection | Recursive (nested structs) | Partial (bug in nested path) | Full |
 | Typed errors | 5 types + errors.As() | Generic | N/A |
 | Context support | Timeouts/cancellation | No | No |
 | C-thread callbacks | crosscall2 | crosscall2 | Full |
 | String/bool/slice args | Raw pointers only | Auto-marshaling | Full |
-| Platform breadth | 6 targets | 9+ architectures | All |
-| AMD64 overhead | 88–114 ns | ~100 ns | ~140 ns (Go 1.26) |
+| Platform breadth | 6 targets | 8 GOARCH / 20+ OS×ARCH | All |
+| AMD64 overhead | 88–114 ns | Not published | ~140 ns (Go 1.26 claims ~30% reduction) |
 
 **Choose goffi** for GPU/real-time workloads: struct passing, zero per-call overhead, callback float returns, typed errors.
 
 **Choose purego** for general-purpose bindings: string auto-marshaling, broad architecture support, less boilerplate.
+
+**See also:** [JupiterRider/ffi](https://github.com/JupiterRider/ffi) — pure Go binding for libffi via purego. Supports struct pass/return and variadic functions; requires libffi at runtime.
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -257,12 +257,12 @@ FFI overhead: 0.0001ms = 0.001% ✅
 
 | Aspect | goffi | purego |
 |--------|-------|-------|
-| **Overhead** | ~100 ns | ~100-150 ns |
-| **Per-call allocations** | Zero (CIF reused) | sync.Pool per call |
+| **Overhead** | ~100 ns | Not published |
+| **Per-call allocations** | Zero (CIF reused) | reflect dispatch + sync.Pool per call |
 | **Type Safety** | ✅ TypeDescriptor validation | Go reflect.Type |
 | **Error Handling** | ✅ 5 typed errors | Generic errors |
 | **Callback float returns** | ✅ XMM0 in asm | ❌ panic |
-| **ARM64 HFA** | Recursive struct walk | Top-level only |
+| **ARM64 HFA** | Recursive struct walk | Partial recursive (bug in nested path) |
 | **Context support** | ✅ Timeouts/cancellation | ❌ |
 | **Platforms** | 5 (quality focus) | 9+ (breadth focus) |
 


### PR DESCRIPTION
## Summary

Update purego comparison claims with data verified directly from purego source code (`reference/purego/`).

**Changes verified from source:**
- ARM64 HFA: "top-level only" → "partial recursive (bug in nested path)" — `struct_arm64.go:256`
- Platforms: "9+" → "8 GOARCH / 20+ OS×ARCH" — 8 `zcallback_*.s` files
- Per-call allocations: added "reflect dispatch" — `func.go` reflect.MakeFunc closure
- Struct pass/return: "Full" → "Partial (no Windows structs)" — issue #237 open
- Callback float returns: clarified "Not supported (panic)" — `syscall_sysv.go:95`
- purego overhead: "~100 ns" → "Not published" — no official benchmarks exist
- Added JupiterRider/ffi to "See also" section

## Test plan

- [ ] CI passes (docs only, no code changes)
- [ ] Comparison table renders correctly on GitHub
