### PR TITLE
fix: add nofakecgo build tag for purego compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-03-03
+
+### Fixed
+- **Unix: duplicate symbol conflict with purego** — added build tag `nofakecgo` to disable goffi's internal fakecgo for projects that already provide `_cgo_init` and related runtime symbols (e.g., via purego). Build with `go build -tags nofakecgo` when using both libraries with `CGO_ENABLED=0` ([#22](https://github.com/go-webgpu/goffi/issues/22))
+
 ### Changed
 - README: replaced static coverage badge with dynamic Codecov badge
+- README: added purego compatibility workaround to Known Limitations
 
 ### Added
 - Unit tests for `types` package: `RuntimeEnvironment`, `DefaultConvention`, type descriptors, constants

--- a/README.md
+++ b/README.md
@@ -252,6 +252,13 @@ if err != nil {
 
 **No bitfields** in struct types.
 
+**Unix: duplicate symbol conflict with purego** ([#22](https://github.com/go-webgpu/goffi/issues/22))
+- When using goffi and purego in the same binary with `CGO_ENABLED=0`, the linker reports `duplicated definition of symbol _cgo_init`. Both libraries include `internal/fakecgo` which defines identical runtime symbols.
+- Workaround: build with `-tags nofakecgo` to disable goffi's fakecgo, relying on purego's copy:
+  ```bash
+  CGO_ENABLED=0 go build -tags nofakecgo ./...
+  ```
+
 ---
 
 ## Platform Support

--- a/ffi/fakecgo_unix.go
+++ b/ffi/fakecgo_unix.go
@@ -1,17 +1,20 @@
-//go:build (linux || darwin) && !cgo
+//go:build (linux || darwin) && !cgo && !nofakecgo
 
 package ffi
 
-// fakecgo enables runtime.cgocall without CGO_ENABLED=1
-// This allows our complete FFI implementation to work safely on Unix-like systems.
+// fakecgo enables runtime.cgocall without CGO_ENABLED=1.
+// This allows goffi's FFI implementation to work safely on Unix-like systems.
 //
-// Status: ✅ FULLY WORKING (Linux, macOS, FreeBSD)
-// ✅ syscall6 (internal/syscall) - Core C function calls
-// ✅ Dlopen/Dlsym/Dlerror (internal/dl) - Library loading
-// ✅ Zero external dependencies - complete independence!
+// The fakecgo package injects runtime.iscgo=true and installs function pointers
+// (_cgo_init, _cgo_thread_start, etc.) that the Go runtime requires for cgocall.
 //
-// The fakecgo package provides runtime.cgocall implementation without CGO.
-// This is REQUIRED for our FFI implementation to work on all Unix platforms.
+// Build tag "nofakecgo" disables this import for projects that already provide
+// these symbols through another package (e.g., purego's internal/fakecgo).
+// Without this tag, linking both goffi and purego with CGO_ENABLED=0 causes:
+//   link: duplicated definition of symbol _cgo_init
+//
+// Usage:
+//   go build -tags nofakecgo ./...   # when purego is also in the dependency tree
 
 import (
 	_ "github.com/go-webgpu/goffi/internal/fakecgo"


### PR DESCRIPTION
## Summary

Fixes #22 — duplicate `_cgo_init` symbol when goffi and purego coexist with `CGO_ENABLED=0`.

Both libraries include `internal/fakecgo` which defines identical runtime symbols (`_cgo_init`, `_cgo_thread_start`, etc.). The Go linker has no `dupok` for data symbols and no weak symbol mechanism, so linking both causes a fatal error.

**Solution:** Add build tag `nofakecgo` to `ffi/fakecgo_unix.go`. Users who also depend on purego can disable goffi's fakecgo:

```bash
CGO_ENABLED=0 go build -tags nofakecgo ./...
```

### Changes

- `ffi/fakecgo_unix.go` — added `!nofakecgo` to build constraint, updated documentation
- `README.md` — added workaround to Known Limitations section
- `CHANGELOG.md` — v0.4.2 release entry

### Why this works

goffi uses `internal/fakecgo` only as a blank import (`import _ "..."`). It needs the **side effect** (setting `runtime.iscgo=true` and installing `_cgo_init`), not any exported API. When purego is present, its identical fakecgo provides the same side effect — one copy is sufficient.

## Test plan

- [x] `go build ./...` passes without tag (default behavior unchanged)
- [x] `go build -tags nofakecgo ./...` passes (fakecgo excluded)
- [x] `go test -v -cover ./...` — all tests pass, 89.6% coverage
- [x] `golangci-lint run` — 0 issues
