### PR TITLE
feat: add Windows ARM64 and FreeBSD amd64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,52 @@ jobs:
           fi
           echo "All files are properly formatted ✓"
 
+  # Cross-compilation - Verify all 7 supported platforms compile
+  cross-compile:
+    name: Cross-Compile
+    runs-on: ubuntu-latest
+    needs: [lint, formatting]
+    env:
+      CGO_ENABLED: 0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Cross-compile all platforms
+        run: |
+          targets=(
+            "linux/amd64"
+            "linux/arm64"
+            "darwin/amd64"
+            "darwin/arm64"
+            "windows/amd64"
+            "windows/arm64"
+            "freebsd/amd64"
+          )
+          FAILED=0
+          for target in "${targets[@]}"; do
+            os="${target%%/*}"
+            arch="${target##*/}"
+            echo "Building ${os}/${arch}..."
+            if GOOS=$os GOARCH=$arch go build ./... 2>&1; then
+              echo "  ✅ ${os}/${arch}"
+            else
+              echo "  ❌ ${os}/${arch} FAILED"
+              FAILED=1
+            fi
+          done
+          if [ $FAILED -eq 1 ]; then
+            echo "❌ Cross-compilation check FAILED"
+            exit 1
+          fi
+          echo "✅ All 7 platforms compile successfully"
+
   # Unit tests - Platform-specific (Linux + Windows + macOS AMD64)
   test:
     name: Test - ${{ matrix.os }}
@@ -277,7 +323,7 @@ jobs:
   # Final status - All checks passed
   ci-success:
     name: CI Success
-    needs: [lint, formatting, test, benchmarks, quality-gate]
+    needs: [lint, formatting, cross-compile, test, benchmarks, quality-gate]
     runs-on: ubuntu-latest
     if: success()
     steps:
@@ -286,6 +332,7 @@ jobs:
           echo "✅ All CI checks passed!"
           echo "✅ Lint: PASSED"
           echo "✅ Formatting: PASSED"
+          echo "✅ Cross-Compile: PASSED (7 platforms)"
           echo "✅ Tests: PASSED"
           echo "   - Linux AMD64 (ubuntu-latest)"
           echo "   - Windows AMD64 (windows-latest)"
@@ -293,5 +340,5 @@ jobs:
           echo "✅ Benchmarks: PASSED"
           echo "✅ Quality Gate: PASSED"
           echo ""
-          echo "Note: macOS Intel uses same ABI as Linux AMD64"
+          echo "Note: Windows ARM64 cross-compile verified, runtime tested by community"
           echo "🚀 Ready for merge!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,6 @@ jobs:
             "darwin/arm64"
             "windows/amd64"
             "windows/arm64"
-            # freebsd/amd64 excluded: fakecgo cgo_export_dynamic + missing Execute
-            # See: https://github.com/go-webgpu/goffi/issues/32
           )
           FAILED=0
           for target in "${targets[@]}"; do
@@ -124,11 +122,23 @@ jobs:
               FAILED=1
             fi
           done
+
+          # FreeBSD requires -gcflags="-std" for fakecgo's //go:cgo_export_dynamic
+          echo "Building freebsd/amd64 (with -gcflags for fakecgo)..."
+          if GOOS=freebsd GOARCH=amd64 go build \
+            -gcflags="github.com/go-webgpu/goffi/internal/fakecgo=-std" \
+            ./... 2>&1; then
+            echo "  ✅ freebsd/amd64"
+          else
+            echo "  ❌ freebsd/amd64 FAILED"
+            FAILED=1
+          fi
+
           if [ $FAILED -eq 1 ]; then
             echo "❌ Cross-compilation check FAILED"
             exit 1
           fi
-          echo "✅ All 6 platforms compile successfully"
+          echo "✅ All 7 platforms compile successfully"
 
   # Unit tests - Platform-specific (Linux + Windows + macOS AMD64)
   test:
@@ -333,7 +343,7 @@ jobs:
           echo "✅ All CI checks passed!"
           echo "✅ Lint: PASSED"
           echo "✅ Formatting: PASSED"
-          echo "✅ Cross-Compile: PASSED (6 platforms)"
+          echo "✅ Cross-Compile: PASSED (7 platforms)"
           echo "✅ Tests: PASSED"
           echo "   - Linux AMD64 (ubuntu-latest)"
           echo "   - Windows AMD64 (windows-latest)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
             "darwin/arm64"
             "windows/amd64"
             "windows/arm64"
-            "freebsd/amd64"
+            # freebsd/amd64 excluded: fakecgo cgo_export_dynamic + missing Execute
+            # See: https://github.com/go-webgpu/goffi/issues/32
           )
           FAILED=0
           for target in "${targets[@]}"; do
@@ -127,7 +128,7 @@ jobs:
             echo "❌ Cross-compilation check FAILED"
             exit 1
           fi
-          echo "✅ All 7 platforms compile successfully"
+          echo "✅ All 6 platforms compile successfully"
 
   # Unit tests - Platform-specific (Linux + Windows + macOS AMD64)
   test:
@@ -332,7 +333,7 @@ jobs:
           echo "✅ All CI checks passed!"
           echo "✅ Lint: PASSED"
           echo "✅ Formatting: PASSED"
-          echo "✅ Cross-Compile: PASSED (7 platforms)"
+          echo "✅ Cross-Compile: PASSED (6 platforms)"
           echo "✅ Tests: PASSED"
           echo "   - Linux AMD64 (ubuntu-latest)"
           echo "   - Windows AMD64 (windows-latest)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-03-29
+
+### Added
+- **Windows ARM64 (Snapdragon X) support** — extended AAPCS64 ARM64 implementation to Windows via build tag changes. Uses `runtime.cgocall` (free on Windows without fakecgo). Tested on Samsung Galaxy Book 4 Edge with Snapdragon X Elite ([#31](https://github.com/go-webgpu/goffi/issues/31))
+- **FreeBSD amd64 support** — added `internal/dl/dl_freebsd.go` and `dl_freebsd_nocgo.go` for `libc.so.7` dynamic loading. FreeBSD uses identical System V ABI as Linux. Requires `-gcflags="github.com/go-webgpu/goffi/internal/fakecgo=-std"` for `CGO_ENABLED=0` builds
+- **CI cross-compilation check** — new job validates all 7 supported platforms compile correctly (linux/darwin/windows × amd64 + arm64 + freebsd/amd64)
+
+### Changed
+- Renamed ARM64 files to drop misleading "unix" suffix: `call_unix.go` → `call_arm64.go`, `syscall_unix_arm64.go/s` → `syscall_arm64.go/s`
+- Extended `ffi/dl_windows.go` and `ffi/callback_windows.go` from `windows && amd64` to `windows` (all architectures)
+- Extended 15+ build tags to include `freebsd` alongside `linux || darwin`
+
 ## [0.4.2] - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ffi.CallFunction(cif, sym, unsafe.Pointer(&result), args)
 |---|---------|---------|
 | **Zero CGO** | Pure Go | No C compiler needed. `go get` and build. |
 | **Fast** | 88–114 ns/op | Pre-computed CIF, zero per-call allocations |
-| **Cross-platform** | 6 targets | Windows, Linux, macOS × AMD64 + ARM64 |
+| **Cross-platform** | 7 targets | Windows, Linux, macOS, FreeBSD × AMD64 + ARM64 |
 | **Callbacks** | C→Go safe | `crosscall2` integration, works from any C thread |
 | **Type-safe** | Runtime validation | 5 typed error types with `errors.As()` support |
 | **Struct passing** | Full ABI | ≤8B (RAX), 9–16B (RAX+RDX), >16B (sret) |
@@ -224,7 +224,7 @@ if err != nil {
 | Context support | Timeouts/cancellation | No | No |
 | C-thread callbacks | crosscall2 | crosscall2 | Full |
 | String/bool/slice args | Raw pointers only | Auto-marshaling | Full |
-| Platform breadth | 6 targets | 8 GOARCH / 20+ OS×ARCH | All |
+| Platform breadth | 7 targets | 8 GOARCH / 20+ OS×ARCH | All |
 | AMD64 overhead | 88–114 ns | Not published | ~140 ns (Go 1.26 claims ~30% reduction) |
 
 **Choose goffi** for GPU/real-time workloads: struct passing, zero per-call overhead, callback float returns, typed errors.
@@ -266,11 +266,12 @@ if err != nil {
 | Platform | Arch | ABI | Since | CI |
 |----------|------|-----|-------|----|
 | Windows | amd64 | Win64 | v0.1.0 | Tested |
+| Windows | arm64 | AAPCS64 | v0.5.0 | Tested (Snapdragon X) |
 | Linux | amd64 | System V | v0.1.0 | Tested |
-| macOS | amd64 | System V | v0.1.1 | Tested |
-| FreeBSD | amd64 | System V | v0.1.0 | Untested |
 | Linux | arm64 | AAPCS64 | v0.3.0 | Cross-compile verified |
+| macOS | amd64 | System V | v0.1.1 | Tested |
 | macOS | arm64 | AAPCS64 | v0.3.7 | Tested (M3 Pro) |
+| FreeBSD | amd64 | System V | v0.5.0 | Cross-compile verified |
 
 ---
 
@@ -282,7 +283,8 @@ if err != nil {
 | v0.3.x | Released | ARM64 (AAPCS64), HFA, Apple Silicon |
 | v0.4.0 | Released | crosscall2 for C-thread callbacks |
 | v0.4.1 | Released | ABI compliance audit — 10/11 gaps fixed |
-| **v0.5.0** | **Next** | Variadic functions, builder API, Windows struct packing |
+| v0.4.2 | Released | purego compatibility (`-tags nofakecgo`) |
+| **v0.5.0** | **Next** | Windows ARM64, FreeBSD, variadic functions, builder API |
 | v1.0.0 | Planned | API stability (SemVer 2.0), security audit |
 
 See [CHANGELOG.md](CHANGELOG.md) for version history and [ROADMAP.md](ROADMAP.md) for the full plan.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,10 +263,11 @@ Five typed error types for precise error handling: `InvalidCallInterfaceError`, 
 |----------|-------------|-----|--------|
 | **Linux** | AMD64 | System V | Production |
 | **Windows** | AMD64 | Win64 | Production |
+| **Windows** | ARM64 | AAPCS64 | Production (tested on Snapdragon X) |
 | **macOS** | AMD64 | System V | Production |
-| **FreeBSD** | AMD64 | System V | Production (untested) |
-| **Linux** | ARM64 | AAPCS64 | Production |
 | **macOS** | ARM64 | AAPCS64 | Production (tested on M3 Pro) |
+| **FreeBSD** | AMD64 | System V | Cross-compile verified |
+| **Linux** | ARM64 | AAPCS64 | Production |
 
 ---
 

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64
+//go:build (linux || darwin || freebsd) && amd64
 
 // Package ffi provides callback support for Foreign Function Interface (Unix version).
 // This file implements Go function registration as C callbacks using

--- a/ffi/callback_arm64.go
+++ b/ffi/callback_arm64.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64
+//go:build (linux || darwin || freebsd) && arm64
 
 // Package ffi provides callback support for Foreign Function Interface (ARM64 Unix version).
 // This file implements Go function registration as C callbacks using

--- a/ffi/callback_test.go
+++ b/ffi/callback_test.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && (amd64 || arm64)
+//go:build (linux || darwin || freebsd) && (amd64 || arm64)
 
 package ffi
 

--- a/ffi/callback_windows.go
+++ b/ffi/callback_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows
 
 // Package ffi provides Foreign Function Interface capabilities.
 // This file contains Windows-specific callback implementation using syscall.NewCallback.

--- a/ffi/cgo_unsupported.go
+++ b/ffi/cgo_unsupported.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && cgo
+//go:build (linux || darwin || freebsd) && cgo
 
 // Package ffi cannot be built with CGO_ENABLED=1.
 //

--- a/ffi/dl_unix.go
+++ b/ffi/dl_unix.go
@@ -1,6 +1,6 @@
-//go:build linux && (amd64 || arm64) && !cgo
+//go:build (linux || freebsd) && (amd64 || arm64) && !cgo
 
-// Linux library loading - OUR OWN implementation (NO dependencies!)
+// Unix library loading via dlopen - OUR OWN implementation (NO dependencies!)
 //
 // Status: ✅ FULLY WORKING
 // ✅ syscall6 (internal/syscall) - Core C function calls (~30ns overhead)

--- a/ffi/dl_windows.go
+++ b/ffi/dl_windows.go
@@ -1,4 +1,4 @@
-//go:build windows && amd64
+//go:build windows
 
 package ffi
 

--- a/ffi/fakecgo_unix.go
+++ b/ffi/fakecgo_unix.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && !cgo && !nofakecgo
+//go:build (linux || darwin || freebsd) && !cgo && !nofakecgo
 
 package ffi
 

--- a/internal/arch/amd64/call_unix.go
+++ b/internal/arch/amd64/call_unix.go
@@ -1,4 +1,4 @@
-//go:build amd64 && (linux || darwin)
+//go:build amd64 && (linux || darwin || freebsd)
 
 // Unix implementation using System V AMD64 ABI (Linux, macOS, FreeBSD, etc.)
 // This implementation closely follows purego's proven approach but is OUR OWN code.

--- a/internal/arch/arm64/call_arm64.go
+++ b/internal/arch/arm64/call_arm64.go
@@ -1,7 +1,8 @@
-//go:build arm64 && (linux || darwin)
+//go:build arm64 && (linux || darwin || windows)
 
-// Unix implementation using AAPCS64 ABI (Linux, macOS on ARM64)
-// This implementation follows the ARM64 Procedure Call Standard.
+// AAPCS64 ABI implementation (Linux, macOS, Windows on ARM64)
+// Windows ARM64 uses the same calling convention as Unix ARM64 for non-variadic functions.
+// See: https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions
 
 package arm64
 

--- a/internal/dl/dl_freebsd.go
+++ b/internal/dl/dl_freebsd.go
@@ -1,0 +1,30 @@
+//go:build freebsd
+
+// FreeBSD-specific constants for dynamic library loading.
+//
+// FreeBSD uses the same POSIX dlopen/dlsym API as Linux and macOS.
+// RTLD_NOW, RTLD_GLOBAL, RTLD_LOCAL, RTLD_LAZY match Linux values.
+// RTLD_DEFAULT matches macOS value (not Linux).
+//
+// Reference: https://github.com/freebsd/freebsd-src/blob/main/include/dlfcn.h
+
+package dl
+
+// RTLD constants from <dlfcn.h> for dynamic library loading on FreeBSD.
+const (
+	// RTLD_LAZY performs relocations at an implementation-dependent time.
+	RTLD_LAZY = 0x00001
+
+	// RTLD_NOW resolves all symbols when loading the library (recommended).
+	RTLD_NOW = 0x00002
+
+	// RTLD_GLOBAL makes all symbols available for relocation processing of other modules.
+	RTLD_GLOBAL = 0x00100
+
+	// RTLD_LOCAL makes symbols not available for relocation processing by other modules.
+	RTLD_LOCAL = 0x00000
+)
+
+// RTLD_DEFAULT is a pseudo-handle for dlsym to search for any loaded symbol.
+// Same value as macOS, different from Linux (0x00000).
+const RTLD_DEFAULT = 1<<64 - 2 // -2 as uintptr

--- a/internal/dl/dl_freebsd_nocgo.go
+++ b/internal/dl/dl_freebsd_nocgo.go
@@ -1,0 +1,15 @@
+//go:build freebsd && !cgo
+
+package dl
+
+// Link to libc.so.7 functions using cgo_import_dynamic.
+// On FreeBSD, dlopen/dlsym/dlclose are part of libc directly
+// (unlike Linux where they're in a separate libdl.so.2).
+
+//go:cgo_import_dynamic goffi_dlopen dlopen "libc.so.7"
+//go:cgo_import_dynamic goffi_dlsym dlsym "libc.so.7"
+//go:cgo_import_dynamic goffi_dlerror dlerror "libc.so.7"
+//go:cgo_import_dynamic goffi_dlclose dlclose "libc.so.7"
+
+// Force dependency on libc.so.7
+//go:cgo_import_dynamic _ _ "libc.so.7"

--- a/internal/dl/dl_stubs_arm64.s
+++ b/internal/dl/dl_stubs_arm64.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64 && !cgo
+//go:build (linux || darwin || freebsd) && arm64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/dl/dl_stubs_unix.s
+++ b/internal/dl/dl_stubs_unix.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64 && !cgo
+//go:build (linux || darwin || freebsd) && amd64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/dl/dl_unix.go
+++ b/internal/dl/dl_unix.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && !cgo
+//go:build (linux || darwin || freebsd) && !cgo
 
 // OUR OWN Dlopen/Dlsym implementation - NO dependencies!
 // Uses runtime.cgocall approach similar to syscall6.

--- a/internal/dl/dl_wrappers_arm64.s
+++ b/internal/dl/dl_wrappers_arm64.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64 && !cgo
+//go:build (linux || darwin || freebsd) && arm64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/dl/dl_wrappers_unix.s
+++ b/internal/dl/dl_wrappers_unix.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64 && !cgo
+//go:build (linux || darwin || freebsd) && amd64 && !cgo
 
 #include "textflag.h"
 

--- a/internal/syscall/syscall_arm64.go
+++ b/internal/syscall/syscall_arm64.go
@@ -1,7 +1,7 @@
-//go:build (linux || darwin) && arm64
+//go:build (linux || darwin || windows) && arm64
 
-// AAPCS64 ABI syscall implementation (Linux, macOS on ARM64)
-// ARM64 Procedure Call Standard - identical on all Unix-like systems.
+// AAPCS64 ABI syscall implementation (Linux, macOS, Windows on ARM64)
+// ARM64 Procedure Call Standard - identical across all platforms.
 package syscall
 
 import (

--- a/internal/syscall/syscall_arm64.s
+++ b/internal/syscall/syscall_arm64.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && arm64
+//go:build (linux || darwin || windows) && arm64
 
 #include "textflag.h"
 #include "abi_arm64.h"

--- a/internal/syscall/syscall_unix_amd64.go
+++ b/internal/syscall/syscall_unix_amd64.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64
+//go:build (linux || darwin || freebsd) && amd64
 
 // System V AMD64 ABI syscall implementation (Linux, macOS, FreeBSD, etc.)
 // This calling convention is IDENTICAL on all Unix-like systems.

--- a/internal/syscall/syscall_unix_amd64.s
+++ b/internal/syscall/syscall_unix_amd64.s
@@ -1,4 +1,4 @@
-//go:build (linux || darwin) && amd64
+//go:build (linux || darwin || freebsd) && amd64
 
 #include "textflag.h"
 #include "abi_amd64.h"


### PR DESCRIPTION
## Summary

- **Windows ARM64 (Snapdragon X) support** -- extended existing AAPCS64 ARM64 implementation to Windows via build tag changes. Zero new assembly -- Windows ARM64 ABI is identical to Unix ARM64 for non-variadic functions. Tested on Samsung Galaxy Book 4 Edge (Snapdragon X Elite) by @SideFx
- **FreeBSD amd64 support** -- added `libc.so.7` dynamic loading (`dl_freebsd.go`, `dl_freebsd_nocgo.go`). Extended 15+ build tags to include `freebsd`
- **CI cross-compilation** -- new job validates all 7 platforms compile: linux/darwin/windows x amd64+arm64 + freebsd/amd64

### Key findings from research

- `syscall.SyscallN` is broken for float args on ARM64 Windows (Go runtime TODO in `asmstdcall`) -- used `runtime.cgocall` instead
- `runtime.cgocall` works on Windows without fakecgo (`cgocall.go:135` explicitly exempts Windows)
- FreeBSD dlopen lives in `libc.so.7` (not `libdl.so.2`), requires `-gcflags` for fakecgo

### Platform support: 6 -> 7 targets

| Platform | Arch | Status |
|----------|------|--------|
| Windows | ARM64 | **NEW** -- tested on Snapdragon X Elite |
| FreeBSD | AMD64 | **NEW** -- cross-compile verified |

Resolves #31

## Test plan

- [x] All tests pass on Windows AMD64 (host)
- [x] All tests pass on Snapdragon X Elite (Windows ARM64) -- confirmed by @SideFx
- [x] Cross-compilation succeeds for all 7 platforms
- [x] CI green (lint, formatting, tests on 3 platforms, benchmarks, quality gate)
- [x] `go fmt ./...` clean
- [x] No private files committed (`.claude/`, `docs/dev/`, `tmp/`)
