### PR TITLE
fix: replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -103,7 +103,7 @@ func validateCallbackSignature(typ reflect.Type) {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 			reflect.Uintptr, reflect.Float32, reflect.Float64,
-			reflect.Ptr, reflect.UnsafePointer, reflect.Bool:
+			reflect.Pointer, reflect.UnsafePointer, reflect.Bool:
 			// Valid types
 		default:
 			panic("ffi: unsupported callback argument type: " + argType.Kind().String())
@@ -121,7 +121,7 @@ func validateCallbackSignature(typ reflect.Type) {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 			reflect.Uintptr, reflect.Float32, reflect.Float64,
-			reflect.Ptr, reflect.UnsafePointer, reflect.Bool:
+			reflect.Pointer, reflect.UnsafePointer, reflect.Bool:
 			// Valid return types
 		default:
 			panic("ffi: unsupported callback return type: " + retType.Kind().String())
@@ -241,7 +241,7 @@ func callbackWrap(a *callbackArgs) {
 				stackIdx++
 			}
 
-		case reflect.Ptr:
+		case reflect.Pointer:
 			// Pointers come from integer registers.
 			// The register contains the actual pointer value from C code.
 			// Using unsafe.Pointer is necessary to convert uintptr (from register)
@@ -308,7 +308,7 @@ func callbackWrap(a *callbackArgs) {
 			} else {
 				a.result = 0
 			}
-		case reflect.Ptr, reflect.UnsafePointer:
+		case reflect.Pointer, reflect.UnsafePointer:
 			a.result = ret.Pointer()
 		case reflect.Float32, reflect.Float64:
 			// For float returns, store the bits as uintptr


### PR DESCRIPTION
## Summary

- Replace 4 occurrences of `reflect.Ptr` with `reflect.Pointer` in `ffi/callback.go`
- `reflect.Ptr` deprecated since Go 1.18, golangci-lint v2.12.1 now flags it via govet inline checker

## Context

CI lint failure blocking PR #37. This is pre-existing tech debt, not related to #37's changes.

## Test plan

- [ ] Lint passes (the only change is constant rename, semantically identical)
- [ ] Build passes
- [ ] Tests pass