### PR TITLE
feat: support callback struct arguments on AMD64 

### DIFF
--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -333,7 +333,7 @@ func callbackWrap(a *callbackArgs) {
 					if bytesLeft >= 8 {
 						*(*uintptr)(chunkPtr) = chunk
 					} else {
-						writePartial(chunkPtr, bytesLeft, getInt())
+						writePartial(chunkPtr, bytesLeft, chunk)
 					}
 					stackIdx++
 				}

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -290,7 +290,7 @@ func callbackWrap(a *callbackArgs) {
 
 		case reflect.Struct:
 			sz := argType.Size()
-			structData := make([]byte, sz)
+			structData := make([]byte, max(sz, 8))
 			var valPtr unsafe.Pointer
 			if sz > 0 {
 				valPtr = unsafe.Pointer(&structData[0])

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -289,9 +289,13 @@ func callbackWrap(a *callbackArgs) {
 			}
 
 		case reflect.Struct:
-			val = reflect.New(argType)
-			valPtr := val.UnsafePointer()
 			sz := argType.Size()
+			structData := make([]byte, sz)
+			var valPtr unsafe.Pointer
+			if sz > 0 {
+				valPtr = unsafe.Pointer(&structData[0])
+			}
+
 			switch {
 			case sz == 0:
 				// Zero-size struct: no fields to populate
@@ -334,6 +338,9 @@ func callbackWrap(a *callbackArgs) {
 					stackIdx++
 				}
 			}
+			val = reflect.New(argType)
+			valByteSlice := unsafe.Slice((*byte)(val.UnsafePointer()), sz)
+			copy(valByteSlice, structData)
 			val = val.Elem()
 
 		default:

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -409,23 +409,17 @@ func isStructAllFloats(structType reflect.Type) bool {
 // [startOff, endOff) are SSE types (float or double).
 // Returns false if any field in the range is INTEGER class, or if no fields lie in the range.
 func classifyEightbyte(structType reflect.Type, startOff, endOff uintptr) bool {
-	var offset uintptr
 	allFloat := true
 	hasField := false
 	for i := range structType.NumField() {
 		field := structType.Field(i)
-		align := uintptr(field.Type.Align())
-		if align > 0 {
-			offset = (offset + align - 1) &^ (align - 1)
-		}
-		if offset >= startOff && offset < endOff {
+		if field.Offset >= startOff && field.Offset < endOff {
 			hasField = true
 			if field.Type.Kind() != reflect.Float32 && field.Type.Kind() != reflect.Float64 {
 				allFloat = false
 				break
 			}
 		}
-		offset += field.Type.Size()
 	}
 	return hasField && allFloat
 }

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -398,7 +398,11 @@ func isStructAllFloats(structType reflect.Type) bool {
 
 	for i := range structType.NumField() {
 		field := structType.Field(i)
-		if field.Type.Kind() != reflect.Float32 && field.Type.Kind() != reflect.Float64 {
+		if field.Type.Kind() == reflect.Struct {
+			if !isStructAllFloats(field.Type) {
+				return false
+			}
+		} else if field.Type.Kind() != reflect.Float32 && field.Type.Kind() != reflect.Float64 {
 			return false
 		}
 	}

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -103,7 +103,7 @@ func validateCallbackSignature(typ reflect.Type) {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 			reflect.Uintptr, reflect.Float32, reflect.Float64,
-			reflect.Pointer, reflect.UnsafePointer, reflect.Bool:
+			reflect.Pointer, reflect.UnsafePointer, reflect.Bool, reflect.Struct:
 			// Valid types
 		default:
 			panic("ffi: unsupported callback argument type: " + argType.Kind().String())
@@ -192,6 +192,46 @@ func callbackWrap(a *callbackArgs) {
 	var intIdx int                        // Current integer register index (0-5)
 	stackIdx := numFloatRegs + numIntRegs // Stack arguments start after registers
 
+	getFloat := func() float64 {
+		// Float64 comes from XMM register
+		if floatIdx < numFloatRegs {
+			bits := frame[floatIdx]
+			floatIdx++
+			return *(*float64)(unsafe.Pointer(&bits))
+		} else {
+			bits := frame[stackIdx]
+			stackIdx++
+			return *(*float64)(unsafe.Pointer(&bits))
+		}
+	}
+
+	getInt := func() uintptr {
+		var value uintptr
+		if intIdx < numIntRegs {
+			value = frame[numFloatRegs+intIdx]
+			intIdx++
+		} else {
+			// All register slots are used: value is on the stack
+			value = frame[stackIdx]
+			stackIdx++
+		}
+		return value
+	}
+
+	// Write only some bytes to a struct to avoid overwrite.
+	writePartial := func(dest unsafe.Pointer, size uintptr, value uintptr) {
+		switch {
+		case size == 1:
+			*(*uint8)(dest) = uint8(value)
+		case size == 2:
+			*(*uint16)(dest) = uint16(value)
+		case size <= 4:
+			*(*uint32)(dest) = uint32(value)
+		default:
+			*(*uintptr)(dest) = value
+		}
+	}
+
 	// Build argument slice for reflection Call
 	args := make([]reflect.Value, numArgs)
 
@@ -201,34 +241,10 @@ func callbackWrap(a *callbackArgs) {
 
 		switch argType.Kind() {
 		case reflect.Float32:
-			// Float32 comes from XMM register (stored as float64)
-			if floatIdx < numFloatRegs {
-				// Read as uintptr, reinterpret as float64 bits
-				bits := frame[floatIdx]
-				f64 := *(*float64)(unsafe.Pointer(&bits))
-				val = reflect.ValueOf(float32(f64))
-				floatIdx++
-			} else {
-				// From stack
-				bits := frame[stackIdx]
-				f64 := *(*float64)(unsafe.Pointer(&bits))
-				val = reflect.ValueOf(float32(f64))
-				stackIdx++
-			}
+			val = reflect.ValueOf(float32(getFloat()))
 
 		case reflect.Float64:
-			// Float64 comes from XMM register
-			if floatIdx < numFloatRegs {
-				bits := frame[floatIdx]
-				f64 := *(*float64)(unsafe.Pointer(&bits))
-				val = reflect.ValueOf(f64)
-				floatIdx++
-			} else {
-				bits := frame[stackIdx]
-				f64 := *(*float64)(unsafe.Pointer(&bits))
-				val = reflect.ValueOf(f64)
-				stackIdx++
-			}
+			val = reflect.ValueOf(getFloat())
 
 		case reflect.Bool:
 			// Bool comes from integer register
@@ -272,16 +288,58 @@ func callbackWrap(a *callbackArgs) {
 				stackIdx++
 			}
 
+		case reflect.Struct:
+			val = reflect.New(argType)
+			valPtr := val.UnsafePointer()
+			sz := argType.Size()
+			switch {
+			case sz == 0:
+				// Zero-size struct: no fields to populate
+
+			case sz <= 8:
+				// Single eightbyte: INTEGER if any member is not float/double, else SSE.
+				if isStructAllFloats(argType) {
+					*(*float64)(valPtr) = getFloat()
+				} else {
+					writePartial(valPtr, sz, getInt())
+				}
+			case sz <= 16:
+				// Two eightbytes: classify each independently.
+				// System V ABI §3.2.3: INTEGER wins over SSE within an eightbyte.
+				if classifyEightbyte(argType, 0, 8) {
+					*(*float64)(valPtr) = getFloat()
+				} else {
+					*(*uintptr)(valPtr) = getInt()
+				}
+				remaining := sz - 8
+				valPtr = unsafe.Add(valPtr, 8)
+				if classifyEightbyte(argType, 8, sz) {
+					*(*float64)(valPtr) = getFloat()
+				} else {
+					writePartial(valPtr, remaining, getInt())
+				}
+			default:
+				// MEMORY class (> 16 bytes): copy from the stack in 8-byte chunks.
+				// Per SysV ABI §3.2.3: MEMORY class structs bypass registers entirely.
+				nChunks := (sz + 7) / 8
+				for k := range nChunks {
+					chunkPtr := unsafe.Add(valPtr, k*8)
+					chunk := frame[stackIdx]
+					bytesLeft := sz - k*8
+					if bytesLeft >= 8 {
+						*(*uintptr)(chunkPtr) = chunk
+					} else {
+						writePartial(chunkPtr, bytesLeft, getInt())
+					}
+					stackIdx++
+				}
+			}
+			val = val.Elem()
+
 		default:
 			// All other integer types (int, uint, int32, etc.)
-			if intIdx < numIntRegs {
-				pos := numFloatRegs + intIdx
-				val = reflect.NewAt(argType, unsafe.Pointer(&frame[pos])).Elem()
-				intIdx++
-			} else {
-				val = reflect.NewAt(argType, unsafe.Pointer(&frame[stackIdx])).Elem()
-				stackIdx++
-			}
+			value := getInt()
+			val = reflect.NewAt(argType, unsafe.Pointer(&value)).Elem()
 		}
 
 		args[i] = val
@@ -322,3 +380,45 @@ func callbackWrap(a *callbackArgs) {
 //go:linkname _callbackTrampoline github.com/go-webgpu/goffi/ffi.callbackTrampoline
 var _callbackTrampoline byte
 var trampolineBaseAddr = uintptr(unsafe.Pointer(&_callbackTrampoline))
+
+// isStructAllFloats returns true if every member of a flat struct is float or double.
+// Per System V AMD64 ABI §3.2.3: if any member in an eightbyte is INTEGER class,
+// the entire eightbyte is classified as INTEGER (INTEGER wins over SSE).
+func isStructAllFloats(structType reflect.Type) bool {
+	if structType.NumField() == 0 {
+		return false
+	}
+
+	for i := range structType.NumField() {
+		field := structType.Field(i)
+		if field.Type.Kind() != reflect.Float32 && field.Type.Kind() != reflect.Float64 {
+			return false
+		}
+	}
+	return true
+}
+
+// classifyEightbyte returns true if all struct fields whose offset falls within
+// [startOff, endOff) are SSE types (float or double).
+// Returns false if any field in the range is INTEGER class, or if no fields lie in the range.
+func classifyEightbyte(structType reflect.Type, startOff, endOff uintptr) bool {
+	var offset uintptr
+	allFloat := true
+	hasField := false
+	for i := range structType.NumField() {
+		field := structType.Field(i)
+		align := uintptr(field.Type.Align())
+		if align > 0 {
+			offset = (offset + align - 1) &^ (align - 1)
+		}
+		if offset >= startOff && offset < endOff {
+			hasField = true
+			if field.Type.Kind() != reflect.Float32 && field.Type.Kind() != reflect.Float64 {
+				allFloat = false
+				break
+			}
+		}
+		offset += field.Type.Size()
+	}
+	return hasField && allFloat
+}

--- a/ffi/callback.go
+++ b/ffi/callback.go
@@ -412,6 +412,8 @@ func isStructAllFloats(structType reflect.Type) bool {
 // classifyEightbyte returns true if all struct fields whose offset falls within
 // [startOff, endOff) are SSE types (float or double).
 // Returns false if any field in the range is INTEGER class, or if no fields lie in the range.
+//
+// CAUTION: Does not currently support nested structs.
 func classifyEightbyte(structType reflect.Type, startOff, endOff uintptr) bool {
 	allFloat := true
 	hasField := false

--- a/ffi/callback_struct_args_test.go
+++ b/ffi/callback_struct_args_test.go
@@ -3,6 +3,7 @@
 package ffi
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
 )
@@ -217,4 +218,49 @@ func TestCallbackStruct20B(t *testing.T) {
 	frame[callbackStackIndex(1)] = uintptr(0x0F0E0D0C0B0A0908)
 	frame[callbackStackIndex(2)] = uintptr(0x00000011)
 	testCallbackStruct(t, frame, expected)
+}
+
+func TestIsStructAllFloats(t *testing.T) {
+	tests := []struct {
+		name     string
+		struct_  any
+		expected bool
+	}{
+		{"empty", struct{}{}, false},
+		{"float32", struct {
+			a float32
+		}{}, true},
+		{"float64", struct {
+			a float64
+		}{}, true},
+		{"two floats", struct {
+			a float32
+			b float64
+		}{}, true},
+		{"mixed", struct {
+			a float32
+			b int
+		}{}, false},
+		{"nested, float", struct {
+			a float32
+			b struct{ a float32 }
+		}{}, true},
+		{"nested, mixed", struct {
+			a float32
+			b struct {
+				a float32
+				b int
+			}
+		}{}, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			typ := reflect.ValueOf(test.struct_).Type()
+			isAllFLoats := isStructAllFloats(typ)
+			if isAllFLoats != test.expected {
+				t.Fatalf("expected %t, but is %t", test.expected, isAllFLoats)
+			}
+		})
+	}
 }

--- a/ffi/callback_struct_args_test.go
+++ b/ffi/callback_struct_args_test.go
@@ -170,45 +170,51 @@ func TestCallbackStruct16BIntFloat(t *testing.T) {
 
 func TestCallbackStruct17B(t *testing.T) {
 	type struct_ struct {
-		a int64
-		b int64
-		c int8 // partial chunk - 1 byte
+		a [16]byte
+		b uint8 // partial chunk - 1 byte
 	}
-	expected := struct_{a: 10, b: 20, c: 30}
+	expected := struct_{
+		a: [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		b: 0x11,
+	}
 
 	frame := [128]uintptr{}
-	frame[callbackStackIndex(0)] = uintptr(expected.a)
-	frame[callbackStackIndex(1)] = uintptr(expected.b)
-	frame[callbackStackIndex(2)] = uintptr(expected.c)
+	frame[callbackStackIndex(0)] = uintptr(0x0706050403020100)
+	frame[callbackStackIndex(1)] = uintptr(0x0F0E0D0C0B0A0908)
+	frame[callbackStackIndex(2)] = uintptr(0x11)
 	testCallbackStruct(t, frame, expected)
 }
 
 func TestCallbackStruct18B(t *testing.T) {
 	type struct_ struct {
-		a int64
-		b int64
-		c int16 // partial chunk - 2 bytes
+		a [16]byte
+		b uint16 // partial chunk - 2 bytes
 	}
-	expected := struct_{a: 10, b: 20, c: 30}
+	expected := struct_{
+		a: [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		b: 0x0011,
+	}
 
 	frame := [128]uintptr{}
-	frame[callbackStackIndex(0)] = uintptr(expected.a)
-	frame[callbackStackIndex(1)] = uintptr(expected.b)
-	frame[callbackStackIndex(2)] = uintptr(expected.c)
+	frame[callbackStackIndex(0)] = uintptr(0x0706050403020100)
+	frame[callbackStackIndex(1)] = uintptr(0x0F0E0D0C0B0A0908)
+	frame[callbackStackIndex(2)] = uintptr(0x0011)
 	testCallbackStruct(t, frame, expected)
 }
 
 func TestCallbackStruct20B(t *testing.T) {
 	type struct_ struct {
-		a int64
-		b int64
-		c int32 // partial chunk - 4 bytes
+		a [16]byte
+		b uint32 // partial chunk - 4 bytes
 	}
-	expected := struct_{a: 10, b: 20, c: 30}
+	expected := struct_{
+		a: [16]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		b: 0x00000011,
+	}
 
 	frame := [128]uintptr{}
-	frame[callbackStackIndex(0)] = uintptr(expected.a)
-	frame[callbackStackIndex(1)] = uintptr(expected.b)
-	frame[callbackStackIndex(2)] = uintptr(expected.c)
+	frame[callbackStackIndex(0)] = uintptr(0x0706050403020100)
+	frame[callbackStackIndex(1)] = uintptr(0x0F0E0D0C0B0A0908)
+	frame[callbackStackIndex(2)] = uintptr(0x00000011)
 	testCallbackStruct(t, frame, expected)
 }

--- a/ffi/callback_struct_args_test.go
+++ b/ffi/callback_struct_args_test.go
@@ -1,4 +1,4 @@
-//go:build (linux || darwin || freebsd) && (amd64 || arm64)
+//go:build (linux || darwin || freebsd) && amd64
 
 package ffi
 

--- a/ffi/callback_struct_args_test.go
+++ b/ffi/callback_struct_args_test.go
@@ -1,0 +1,214 @@
+//go:build (linux || darwin || freebsd) && (amd64 || arm64)
+
+package ffi
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func testCallbackStruct[T comparable](
+	t *testing.T,
+	// Argument frame (System V AMD64 ABI)
+	// Layout: [XMM0-7][RDI,RSI,RDX,RCX,R8,R9][stack...]
+	frame [128]uintptr,
+	// A struct that is the expected callback argument
+	expected T,
+) {
+	t.Helper()
+
+	var arg T
+	callback := func(s T) { arg = s }
+
+	ptr := NewCallback(callback)
+	if ptr == 0 {
+		t.Fatal("NewCallback returned nil pointer")
+	}
+
+	idx := callbackIndex(ptr)
+
+	args := &callbackArgs{
+		index: idx,
+		args:  unsafe.Pointer(&frame),
+	}
+
+	callbackWrap(args)
+
+	if arg != expected {
+		t.Errorf("Expected result %#v, got %#v", expected, arg)
+	}
+}
+
+func TestCallbackStructEmpty(t *testing.T) {
+	type struct_ struct{}
+	testCallbackStruct(t, [128]uintptr{}, struct_{})
+}
+
+func TestCallbackStructSingleFloat(t *testing.T) {
+	type struct_ struct{ a float32 }
+	expected := struct_{a: 3.14}
+
+	testCallbackStruct(t, [128]uintptr{
+		*(*uintptr)(unsafe.Pointer(&expected.a)), // XMM0
+	}, expected)
+}
+
+func TestCallbackStruct8BTwoFloat32s(t *testing.T) {
+	type struct_ struct {
+		a float32
+		b float32
+	}
+	expected := struct_{a: 3.14, b: 2.86}
+
+	// Pack 2 floats in to a 64 bit area.
+	var floats [8]byte
+	*(*float32)(unsafe.Pointer(&floats[0])) = expected.a
+	*(*float32)(unsafe.Pointer(&floats[4])) = expected.b
+	frame := [128]uintptr{}
+	frame[0] = *(*uintptr)(unsafe.Pointer(&floats)) // XMM0
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct8BFloat64(t *testing.T) {
+	type struct_ struct {
+		a float64
+	}
+	expected := struct_{a: 3.14}
+
+	frame := [128]uintptr{}
+	frame[0] = *(*uintptr)(unsafe.Pointer(&expected.a)) // XMM0
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct8BMixedIntegers3(t *testing.T) {
+	type struct_ struct {
+		a byte
+		b int16
+	}
+	expected := struct_{a: 0x10, b: 0x2000}
+
+	frame := [128]uintptr{}
+	frame[callbackIntRegIndex(0)] = 0x20000010 // first int arg
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct6BMixedIntegers(t *testing.T) {
+	type struct_ struct {
+		a byte
+		b int16
+		c byte
+	}
+	expected := struct_{a: 0x10, b: 0x2000, c: 0x30}
+
+	frame := [128]uintptr{}
+	frame[callbackIntRegIndex(0)] = 0x3020000010 // first int arg
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct8BInt64(t *testing.T) {
+	type struct_ struct {
+		a int64
+	}
+	expected := struct_{a: -10}
+
+	frame := [128]uintptr{}
+	frame[callbackIntRegIndex(0)] = uintptr(expected.a) // first int arg
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct16BFloatFloat(t *testing.T) {
+	type struct_ struct {
+		a float64
+		b float64
+	}
+	expected := struct_{a: 3.14, b: 2.86}
+
+	frame := [128]uintptr{}
+	frame[0] = *(*uintptr)(unsafe.Pointer(&expected.a)) // XMM0
+	frame[1] = *(*uintptr)(unsafe.Pointer(&expected.b)) // XMM1
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct16BIntInt(t *testing.T) {
+	type struct_ struct {
+		a int64
+		b int64
+	}
+	expected := struct_{a: 10, b: 20}
+
+	frame := [128]uintptr{}
+	frame[callbackIntRegIndex(0)] = uintptr(expected.a) // first int arg
+	frame[callbackIntRegIndex(1)] = uintptr(expected.b) // second int arg
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct16BFloatInt(t *testing.T) {
+	type struct_ struct {
+		a float64
+		b int64
+	}
+	expected := struct_{a: 3.14, b: 20}
+
+	frame := [128]uintptr{}
+	frame[0] = *(*uintptr)(unsafe.Pointer(&expected.a)) // XMM0
+	frame[callbackIntRegIndex(0)] = uintptr(expected.b) // first int arg
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct16BIntFloat(t *testing.T) {
+	type struct_ struct {
+		a int64
+		b float64
+	}
+	expected := struct_{a: 20, b: 3.14}
+
+	frame := [128]uintptr{}
+	frame[callbackIntRegIndex(0)] = uintptr(expected.a) // first int arg
+	frame[0] = *(*uintptr)(unsafe.Pointer(&expected.b)) // XMM0
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct17B(t *testing.T) {
+	type struct_ struct {
+		a int64
+		b int64
+		c int8 // partial chunk - 1 byte
+	}
+	expected := struct_{a: 10, b: 20, c: 30}
+
+	frame := [128]uintptr{}
+	frame[callbackStackIndex(0)] = uintptr(expected.a)
+	frame[callbackStackIndex(1)] = uintptr(expected.b)
+	frame[callbackStackIndex(2)] = uintptr(expected.c)
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct18B(t *testing.T) {
+	type struct_ struct {
+		a int64
+		b int64
+		c int16 // partial chunk - 2 bytes
+	}
+	expected := struct_{a: 10, b: 20, c: 30}
+
+	frame := [128]uintptr{}
+	frame[callbackStackIndex(0)] = uintptr(expected.a)
+	frame[callbackStackIndex(1)] = uintptr(expected.b)
+	frame[callbackStackIndex(2)] = uintptr(expected.c)
+	testCallbackStruct(t, frame, expected)
+}
+
+func TestCallbackStruct20B(t *testing.T) {
+	type struct_ struct {
+		a int64
+		b int64
+		c int32 // partial chunk - 4 bytes
+	}
+	expected := struct_{a: 10, b: 20, c: 30}
+
+	frame := [128]uintptr{}
+	frame[callbackStackIndex(0)] = uintptr(expected.a)
+	frame[callbackStackIndex(1)] = uintptr(expected.b)
+	frame[callbackStackIndex(2)] = uintptr(expected.c)
+	testCallbackStruct(t, frame, expected)
+}

--- a/ffi/struct_e2e_test.go
+++ b/ffi/struct_e2e_test.go
@@ -288,3 +288,231 @@ func TestStructArgWithScalar(t *testing.T) {
 		t.Errorf("take_struct_and_int({10, 20}, 1000) = %d, want %d", result, expected)
 	}
 }
+
+func TestCallbackStructArg8B_IntegerPair(t *testing.T) {
+	requireStructLib(t)
+
+	sym, err := GetSymbol(structTestLib, "callback_struct_8")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cif types.CallInterface
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.SInt32TypeDescriptor,
+			types.UInt32TypeDescriptor,
+			types.PointerTypeDescriptor,
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	type Pair struct {
+		A int32
+		B uint32
+	}
+
+	var receivedArg Pair
+	callback := NewCallback(func(s Pair) {
+		receivedArg = s
+	})
+
+	expected := Pair{42, 10}
+	args := []unsafe.Pointer{
+		unsafe.Pointer(&expected.A),
+		unsafe.Pointer(&expected.B),
+		unsafe.Pointer(&callback),
+	}
+
+	if err := CallFunction(&cif, sym, nil, args); err != nil {
+		t.Fatal(err)
+	}
+
+	if receivedArg != expected {
+		t.Errorf("expected %#v, received %#v", expected, receivedArg)
+	}
+}
+
+func TestCallbackStructArg8B_FloatPair(t *testing.T) {
+	requireStructLib(t)
+
+	sym, err := GetSymbol(structTestLib, "callback_struct_2floats")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cif types.CallInterface
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.FloatTypeDescriptor,
+			types.FloatTypeDescriptor,
+			types.PointerTypeDescriptor,
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	type PairF32 struct {
+		X float32
+		Y float32
+	}
+
+	var receivedArg PairF32
+	callback := NewCallback(func(s PairF32) {
+		receivedArg = s
+	})
+
+	expected := PairF32{2.5, 3.5}
+	args := []unsafe.Pointer{
+		unsafe.Pointer(&expected.X),
+		unsafe.Pointer(&expected.Y),
+		unsafe.Pointer(&callback),
+	}
+
+	if err := CallFunction(&cif, sym, nil, args); err != nil {
+		t.Fatal(err)
+	}
+
+	if receivedArg != expected {
+		t.Errorf("expected %#v, received %#v", expected, receivedArg)
+	}
+}
+
+func TestCallbackStructArg16B(t *testing.T) {
+	requireStructLib(t)
+
+	sym, err := GetSymbol(structTestLib, "callback_struct_16")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cif types.CallInterface
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.SInt64TypeDescriptor,
+			types.SInt64TypeDescriptor,
+			types.PointerTypeDescriptor,
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	type PairI64 struct {
+		A int64
+		B int64
+	}
+
+	var receivedArg PairI64
+	callback := NewCallback(func(s PairI64) {
+		receivedArg = s
+	})
+
+	expected := PairI64{1000000, 2000000}
+	args := []unsafe.Pointer{
+		unsafe.Pointer(&expected.A),
+		unsafe.Pointer(&expected.B),
+		unsafe.Pointer(&callback),
+	}
+
+	if err := CallFunction(&cif, sym, nil, args); err != nil {
+		t.Fatal(err)
+	}
+
+	if receivedArg != expected {
+		t.Errorf("expected %#v, received %#v", expected, receivedArg)
+	}
+}
+
+func TestCallbackStructArg24B_MemoryClass(t *testing.T) {
+	requireStructLib(t)
+
+	sym, err := GetSymbol(structTestLib, "callback_struct_24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cif types.CallInterface
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.SInt64TypeDescriptor,
+			types.SInt64TypeDescriptor,
+			types.SInt64TypeDescriptor,
+			types.PointerTypeDescriptor,
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	type TripleI64 struct {
+		A int64
+		B int64
+		C int64
+	}
+
+	var receivedArg TripleI64
+	callback := NewCallback(func(s TripleI64) {
+		receivedArg = s
+	})
+
+	expected := TripleI64{100, 200, 300}
+	args := []unsafe.Pointer{
+		unsafe.Pointer(&expected.A),
+		unsafe.Pointer(&expected.B),
+		unsafe.Pointer(&expected.C),
+		unsafe.Pointer(&callback),
+	}
+
+	if err := CallFunction(&cif, sym, nil, args); err != nil {
+		t.Fatal(err)
+	}
+
+	if receivedArg != expected {
+		t.Errorf("expected %#v, received %#v", expected, receivedArg)
+	}
+}
+
+func TestCallbackStructArgWithScalar(t *testing.T) {
+	requireStructLib(t)
+
+	sym, err := GetSymbol(structTestLib, "callback_struct_and_int")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var cif types.CallInterface
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.SInt32TypeDescriptor,
+			types.UInt32TypeDescriptor,
+			types.SInt64TypeDescriptor,
+			types.PointerTypeDescriptor,
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	type Pair struct {
+		A int32
+		B uint32
+	}
+
+	var receivedArg1 Pair
+	var receivedArg2 int64
+	callback := NewCallback(func(s Pair, extra int64) {
+		receivedArg1 = s
+		receivedArg2 = extra
+	})
+
+	expected := Pair{10, 20}
+	extra := int64(1000)
+	args := []unsafe.Pointer{
+		unsafe.Pointer(&expected.A),
+		unsafe.Pointer(&expected.B),
+		unsafe.Pointer(&extra),
+		unsafe.Pointer(&callback),
+	}
+
+	if err := CallFunction(&cif, sym, nil, args); err != nil {
+		t.Fatal(err)
+	}
+
+	if receivedArg1 != expected || receivedArg2 != extra {
+		t.Errorf("expected %#v %d, received %#v %d", expected, extra, receivedArg1, receivedArg2)
+	}
+}

--- a/ffi/struct_e2e_test.go
+++ b/ffi/struct_e2e_test.go
@@ -290,6 +290,9 @@ func TestStructArgWithScalar(t *testing.T) {
 }
 
 func TestCallbackStructArg8B_IntegerPair(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("callback struct args not supported on Windows")
+	}
 	requireStructLib(t)
 
 	sym, err := GetSymbol(structTestLib, "callback_struct_8")
@@ -334,6 +337,9 @@ func TestCallbackStructArg8B_IntegerPair(t *testing.T) {
 }
 
 func TestCallbackStructArg8B_FloatPair(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("callback struct args not supported on Windows")
+	}
 	requireStructLib(t)
 
 	sym, err := GetSymbol(structTestLib, "callback_struct_2floats")
@@ -378,6 +384,9 @@ func TestCallbackStructArg8B_FloatPair(t *testing.T) {
 }
 
 func TestCallbackStructArg16B(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("callback struct args not supported on Windows")
+	}
 	requireStructLib(t)
 
 	sym, err := GetSymbol(structTestLib, "callback_struct_16")
@@ -422,6 +431,9 @@ func TestCallbackStructArg16B(t *testing.T) {
 }
 
 func TestCallbackStructArg24B_MemoryClass(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("callback struct args not supported on Windows")
+	}
 	requireStructLib(t)
 
 	sym, err := GetSymbol(structTestLib, "callback_struct_24")
@@ -469,6 +481,9 @@ func TestCallbackStructArg24B_MemoryClass(t *testing.T) {
 }
 
 func TestCallbackStructArgWithScalar(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("callback struct args not supported on Windows")
+	}
 	requireStructLib(t)
 
 	sym, err := GetSymbol(structTestLib, "callback_struct_and_int")

--- a/ffi/struct_e2e_test.go
+++ b/ffi/struct_e2e_test.go
@@ -301,7 +301,7 @@ func TestCallbackStructArg8B_IntegerPair(t *testing.T) {
 	}
 
 	var cif types.CallInterface
-	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.VoidTypeDescriptor,
 		[]*types.TypeDescriptor{
 			types.SInt32TypeDescriptor,
 			types.UInt32TypeDescriptor,
@@ -348,7 +348,7 @@ func TestCallbackStructArg8B_FloatPair(t *testing.T) {
 	}
 
 	var cif types.CallInterface
-	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.VoidTypeDescriptor,
 		[]*types.TypeDescriptor{
 			types.FloatTypeDescriptor,
 			types.FloatTypeDescriptor,
@@ -395,7 +395,7 @@ func TestCallbackStructArg16B(t *testing.T) {
 	}
 
 	var cif types.CallInterface
-	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.VoidTypeDescriptor,
 		[]*types.TypeDescriptor{
 			types.SInt64TypeDescriptor,
 			types.SInt64TypeDescriptor,
@@ -442,7 +442,7 @@ func TestCallbackStructArg24B_MemoryClass(t *testing.T) {
 	}
 
 	var cif types.CallInterface
-	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.VoidTypeDescriptor,
 		[]*types.TypeDescriptor{
 			types.SInt64TypeDescriptor,
 			types.SInt64TypeDescriptor,
@@ -492,7 +492,7 @@ func TestCallbackStructArgWithScalar(t *testing.T) {
 	}
 
 	var cif types.CallInterface
-	if err := PrepareCallInterface(&cif, types.DefaultCall, types.SInt64TypeDescriptor,
+	if err := PrepareCallInterface(&cif, types.DefaultCall, types.VoidTypeDescriptor,
 		[]*types.TypeDescriptor{
 			types.SInt32TypeDescriptor,
 			types.UInt32TypeDescriptor,

--- a/ffi/testdata/structtest.c
+++ b/ffi/testdata/structtest.c
@@ -5,11 +5,21 @@ struct pair_i32_u32 { int32_t a; uint32_t b; };
 int64_t take_struct_8(struct pair_i32_u32 s) {
     return (int64_t)s.a * 1000 + (int64_t)s.b;
 }
+void callback_struct_8(int32_t a, uint32_t b, void (*callback)(struct pair_i32_u32 s))
+{
+    struct pair_i32_u32 s = {.a = a, .b = b};
+    callback(s);
+}
 
 // ≤ 8 bytes: {float, float} — SSE class, single XMM register
 struct pair_f32 { float x; float y; };
 float take_struct_2floats(struct pair_f32 s) {
     return s.x + s.y;
+}
+void callback_struct_2floats(float x, float y, void (*callback)(struct pair_f32 s))
+{
+    struct pair_f32 s = {.x = x, .y = y};
+    callback(s);
 }
 
 // 16 bytes: {int64, int64} — two INTEGER eightbytes
@@ -17,14 +27,30 @@ struct pair_i64 { int64_t a; int64_t b; };
 int64_t take_struct_16(struct pair_i64 s) {
     return s.a + s.b;
 }
+void callback_struct_16(int64_t a, int64_t b, void (*callback)(struct pair_i64 s))
+{
+    struct pair_i64 s = {.a = a, .b = b};
+    callback(s);
+}
 
 // 24 bytes: > 16B — MEMORY class, passed on stack
 struct triple_i64 { int64_t a; int64_t b; int64_t c; };
 int64_t take_struct_24(struct triple_i64 s) {
     return s.a + s.b + s.c;
 }
+void callback_struct_24(int64_t a, int64_t b, int64_t c, void (*callback)(struct triple_i64 s))
+{
+    struct triple_i64 s = {.a = a, .b = b, .c = c};
+    callback(s);
+}
 
 // Mixed: struct arg + scalar args (verify register allocation)
 int64_t take_struct_and_int(struct pair_i32_u32 s, int64_t extra) {
     return (int64_t)s.a + (int64_t)s.b + extra;
+}
+void callback_struct_and_int(int32_t a, uint32_t b, int64_t extra,
+                             void (*callback)(struct pair_i32_u32 s, int64_t extra))
+{
+    struct pair_i32_u32 s = {.a = a, .b = b};
+    callback(s, extra);
 }


### PR DESCRIPTION
Fixes #41 

Adds support for callback struct by-value arguments on AMD64 Unix (System V ABI).

It's the inverse of the struct type arg support in [internal/arch/amd64/call_unix.go](https://github.com/go-webgpu/goffi/blob/main/internal/arch/amd64/call_unix.go).
Instead of marshalling from a struct to registers and the stack, data from
registers and the stack are marshalled in to a struct.

## Pull Request Requirements
- [x] Code is formatted (`go fmt ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] All tests pass with race detector (`go test -race ./...`)
- [x] Benchmarks don't regress (FFI overhead < 200ns)
  - Benchmarks report over 400ns for me locally. But it's the same on `main`, so I guess that my hardware is just slow. In any case it doesn't look like there's any regression.
- [x] New code has tests (minimum 70% coverage, current: 89.1%)
  - On `main` coverage of the `github.com/go-webgpu/goffi/ffi` package is 87.3%. With this PR it's 91.0%.
- [x] Platform-specific code tested on target OS
- [ ] Assembly changes validated on real hardware
  - N/A
- [ ] Documentation updated (if applicable)
- [ ] Commit messages follow conventions
- [x] No sensitive data (credentials, tokens, etc.)

I've tried to broadly follow the practices of the project. But I'm still getting familiar with it, so it's quite possible that I may have deviated too far in places.

I've tried to follow the instructions in https://github.com/go-webgpu/goffi/blob/main/CONTRIBUTING.md where applicable. But I've ignored the references to the `develop` branch, as it appears to be quite out of date. So I've targeted `main`.

## tests

I'm also somewhat new to the intricacies of the function calling ABI. So while all of the tests that I've added pass, it wouldn't surprise me if I have any of the tests wrong. I have tried the implementation out with the use of [clang_visitChildren](https://clang.llvm.org/doxygen/group__CINDEX__CURSOR__TRAVERSAL.html#ga5d0a813d937e1a7dcc35f206ad1f7a91) that was my original use case that prompted #41. And it appears to work, so I have some confidence that the implementation might be broadly on the right lines.

##  data race

There was a data race when writing to the `reflect.Value` used for a new struct. For example at https://github.com/pekim/goffi/blob/bugfix/fix-issue-41/ffi/callback.go#L306.
```go
					*(*float64)(valPtr) = getFloat()
```

Commit https://github.com/pekim/goffi/commit/50eb215f19143d00d641b464ab2dcb575a00847e works around this. But perhaps there's a better approach?

## overhead

The use of a `[]byte` and the subsequent `copy` (to address the data race) will introduce an overhead. But I've not yet managed to find a better solution.