### PR TITLE
fix: example avalue pointer bug + CI examples check (v0.5.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,28 @@ jobs:
           fi
           echo "✅ All 8 platforms compile successfully"
 
+          # Verify examples compile
+          echo ""
+          echo "Building examples..."
+          for example_dir in examples/*/; do
+            if [ -f "${example_dir}go.mod" ]; then
+              example_name=$(basename "$example_dir")
+              echo "Building example: ${example_name}..."
+              if (cd "$example_dir" && go build . 2>&1); then
+                echo "  ✅ ${example_name}"
+              else
+                echo "  ❌ ${example_name} FAILED"
+                FAILED=1
+              fi
+            fi
+          done
+
+          if [ $FAILED -eq 1 ]; then
+            echo "❌ Examples build check FAILED"
+            exit 1
+          fi
+          echo "✅ All examples compile successfully"
+
   # Unit tests - Platform-specific (Linux + Windows + macOS AMD64)
   # Tested under both CGO_ENABLED=0 (fakecgo path) and CGO_ENABLED=1 (real
   # runtime/cgo path). Both modes must pass identically; CGO_ENABLED=0 is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-06-15
+
+### Fixed
+- **Example: avalue pointer bug** — `examples/simple/main.go` passed string pointer directly as avalue instead of pointer-to-pointer on Windows/Linux path. Darwin path was correct. avalue elements must be pointers TO argument values (`unsafe.Pointer(&cstr)`), not values directly. Reported by @lkmavi on Windows 11 ARM64
+- **CI: examples not verified** — added examples build check to cross-compile CI job. All `examples/*/go.mod` modules are now compiled as part of CI pipeline
+
 ## [0.5.4] - 2026-06-15
 
 ### Changed

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -74,8 +74,10 @@ func main() {
 		}
 
 	} else {
-		arg := unsafe.Pointer(unsafe.StringData(str))
-		args := []unsafe.Pointer{arg}
+		cstr := unsafe.Pointer(unsafe.StringData(str))
+
+		// IMPORTANT: args contains pointers to argument *storage*
+		args := []unsafe.Pointer{unsafe.Pointer(&cstr)}
 
 		// Execute function call
 		err = ffi.CallFunction(cif, sym, nil, args)


### PR DESCRIPTION
## Summary

- Fix `examples/simple/main.go`: avalue elements must be pointers TO argument values, not values directly. Darwin path was correct, Windows/Linux path was not
- Add examples build verification to CI — all `examples/*/go.mod` compiled in cross-compile job

## Bug

```go
// WRONG (crashed on Windows 11 ARM64):
arg := unsafe.Pointer(unsafe.StringData(str))
args := []unsafe.Pointer{arg}                    // value directly ❌

// CORRECT:
cstr := unsafe.Pointer(unsafe.StringData(str))
args := []unsafe.Pointer{unsafe.Pointer(&cstr)}  // pointer TO value ✅
```

Reported by @lkmavi on Windows 11 ARM64 (Snapdragon).

## Test plan

- [x] `examples/simple/` compiles locally
- [x] Main module builds and tests pass
- [ ] CI green (includes new examples build check)

Closes: reported via chat, no GitHub issue