### PR TITLE
docs: v0.6.1 release — Android preview, CODEOWNERS, changelog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,15 @@
 /internal/syscall/cgo.go @kolkov @jiyeyuran
 /ffi/callback_cthread_test.go @kolkov @jiyeyuran
 
+# Android ARM64 Bionic - @besmpl maintains Android platform support
+/ffi/*android* @kolkov @besmpl
+/internal/dl/*android* @kolkov @besmpl
+/internal/fakecgo/*android* @kolkov @besmpl
+/internal/syscall/*android* @kolkov @besmpl
+/docs/ANDROID.md @kolkov @besmpl
+/scripts/check-android-arm64.sh @kolkov @besmpl
+/testdata/android_abi_probe.c @kolkov @besmpl
+
 # Examples - Reference implementations
 /examples/ @kolkov
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-21
+
+### Added
+- **Android ARM64 Bionic support (guarded preview)** — Android arm64/API 29+ platform with Bionic loader, `__errno` routing, four-argument `_cgo_init` startup, TLS slot validation, and dual CGO mode support. Callbacks explicitly rejected pending physical-device thread proof. Cross-build, ABI, and ELF gates pass on NDK r29 with Go 1.25.12 and Go 1.26.5. ([PR #62](https://github.com/go-webgpu/goffi/pull/62) by [@besmpl](https://github.com/besmpl))
+- **Android CI matrix** — NDK r29 cross-build and ELF dependency audits for Go 1.25.12 + Go 1.26.5 in both CGO modes
+- **`docs/ANDROID.md`** — runtime ABI contract, NDK probe, callback limitation, and build instructions
+- **@besmpl added as CODEOWNER** for Android paths (`*android*` across `ffi/`, `internal/dl/`, `internal/fakecgo/`, `internal/syscall/`)
+
+### Changed
+- **fakecgo naming cleanup** — all `purego_` dynamic import symbols renamed to `goffi_` across `internal/fakecgo/` (18 files). Dual copyright attribution: Ebitengine Authors + Andrey Kolkov and GoGPU Contributors. ([PR #63](https://github.com/go-webgpu/goffi/pull/63))
+- **LICENSE** updated to `Andrey Kolkov and GoGPU Contributors` (matching gogpu ecosystem pattern)
+- **NOTICE** file added documenting Apache-2.0 heritage of fakecgo from ebitengine/purego
+- Platform count: 8 desktop targets + Android ARM64 preview (9 total)
+
 ## [0.6.0] - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ if err != nil {
 | macOS | arm64 | AAPCS64 | v0.3.7 | Tested (M3 Pro) |
 | FreeBSD | amd64 | System V | v0.5.0 | Cross-compile verified |
 | FreeBSD | arm64 | AAPCS64 | v0.5.3 | Cross-compile verified |
+| Android | arm64 | AAPCS64 (Bionic) | v0.6.1 | Guarded preview (API 29+) |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > **Strategic Approach**: Build production-ready Zero-CGO FFI with benchmarked performance
 > **Philosophy**: Performance first, usability second, platform coverage third
 
-**Last Updated**: 2026-07-12 | **Current Version**: v0.6.0 | **Strategy**: Benchmarks → Callbacks → ARM64 → Runtime → ABI → v1.0 LTS | **Milestone**: v0.6.0 (errno + stack-move fix) → v0.7.0 RegisterFunc/Builder → v1.0.0 LTS
+**Last Updated**: 2026-07-21 | **Current Version**: v0.6.1 | **Strategy**: Benchmarks → Callbacks → ARM64 → Runtime → ABI → v1.0 LTS | **Milestone**: v0.6.1 (Android preview + fakecgo cleanup) → v0.7.0 RegisterFunc/Builder → v1.0.0 LTS
 
 ---
 
@@ -160,6 +160,12 @@ v1.0.0 LTS → Long-term support release (2027 Q1)
 - First pure-Go FFI with correct errno capture on Linux
 - Assembly-level capture inside trampoline (thread-safe window)
 - Platform support: `__errno_location` (Linux), `__error` (macOS/FreeBSD)
+
+**v0.6.1** = Android ARM64 + fakecgo cleanup ✅ RELEASED (2026-07-21)
+- **Android ARM64 Bionic** (guarded preview) — PR #62 by @besmpl
+- fakecgo `purego_` → `goffi_` rename + dual copyright — PR #63
+- LICENSE + NOTICE updated to GoGPU ecosystem pattern
+- @besmpl added as CODEOWNER for Android paths
 
 **v0.7.0** = RegisterFunc + Builder API (2026 Q3-Q4)
 - RegisterFunc convenience API (ADR-008)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -409,6 +409,7 @@ go run github.com/go-webgpu/goffi/cmd/variadic-test
 | **FreeBSD** | AMD64 | System V | Cross-compile verified |
 | **FreeBSD** | ARM64 | AAPCS64 | Cross-compile verified |
 | **Linux** | ARM64 | AAPCS64 | Production |
+| **Android** | ARM64 | AAPCS64 (Bionic) | Guarded preview (API 29+, NDK r29) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add @besmpl as CODEOWNER for Android paths (`*android*` across `ffi/`, `internal/dl/`, `internal/fakecgo/`, `internal/syscall/`)
- CHANGELOG v0.6.1: Android ARM64 Bionic (guarded preview), fakecgo naming cleanup, LICENSE/NOTICE updates
- README: Android arm64 added to platform table
- ARCHITECTURE: Android added to platform support matrix
- ROADMAP: v0.6.1 milestone

## What's in v0.6.1

### Added
- Android ARM64 Bionic support (guarded preview, API 29+, NDK r29) — PR #62 by @besmpl
- Android CI matrix (Go 1.25.12 + Go 1.26.5, dual CGO modes)
- @besmpl as CODEOWNER for Android paths

### Changed
- fakecgo `purego_` → `goffi_` rename (18 files) — PR #63
- LICENSE: `Andrey Kolkov and GoGPU Contributors`
- NOTICE file: Apache-2.0 attribution for fakecgo heritage
- Platform count: 8 desktop + Android preview (9 total)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] Cross-compile 9 platforms (8 desktop + Android ARM64) ✅
- [x] golangci-lint: 0 issues
- [ ] CI green