### PR TITLE
feat: add starhistory.io star chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,18 @@ goffi powers an ecosystem of pure Go GPU libraries:
 
 ---
 
+
+
+## Star History
+
+<a href="https://starhistory.io">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.starhistory.io/png?repos=go-webgpu/goffi&style=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.starhistory.io/png?repos=go-webgpu/goffi&style=professional" />
+   <img alt="Star History Chart" src="https://api.starhistory.io/png?repos=go-webgpu/goffi" width="800" />
+ </picture>
+</a>
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Adds star history chart powered by [starhistory.io](https://starhistory.io). Dark/light mode support via picture element.